### PR TITLE
fix: disable full-text search index on task_index table

### DIFF
--- a/postgres-persistence/src/main/resources/db/migration_postgres/V9__indexing_index_fix.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V9__indexing_index_fix.sql
@@ -7,6 +7,6 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS workflow_index_json_data_gin_idx ON work
 DROP INDEX CONCURRENTLY IF EXISTS task_index_json_data_json_idx;
 DROP INDEX CONCURRENTLY IF EXISTS task_index_json_data_text_idx;
 -- Create the full text index on the json_data column of the task_index table
-CREATE INDEX CONCURRENTLY IF NOT EXISTS task_index_json_data_fulltext_idx ON task_index USING GIN (jsonb_to_tsvector('english', json_data, '["all"]'));
+-- CREATE INDEX CONCURRENTLY IF NOT EXISTS task_index_json_data_fulltext_idx ON task_index USING GIN (jsonb_to_tsvector('english', json_data, '["all"]'));
 -- Create a new index to enable querying the json by attribute and value
 CREATE INDEX CONCURRENTLY IF NOT EXISTS task_index_json_data_gin_idx ON task_index USING GIN (json_data jsonb_path_ops);


### PR DESCRIPTION
This is a migration which consumes a lot of resources. We can skip it since we never use full text search on tasks.