### PR TITLE
feat: swap es7-persistence for os-persistence in server classpath

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -40,10 +40,13 @@ dependencies {
     implementation project(':conductor-mysql-persistence')
     implementation project(':conductor-sqlite-persistence')
 
-    //Indexing (note: Elasticsearch 6 is deprecated)
-    implementation project(':conductor-es7-persistence')
-    // To use Opensearch, comment out above Elasticsearch, uncomment below Opensearch, and rebuild conductor
-    // implementation project(':conductor-os-persistence')
+    //Indexing — using OpenSearch for Conductor task/workflow search.
+    //ES7 is intentionally NOT included: both modules declare beans with the same name
+    //(`restClient`) and both mark IndexDAO as @Primary, so a misconfiguration that activates
+    //both conditions simultaneously would fail at startup. Rollback path is via
+    //conductor.indexing.type=postgres (PostgresIndexDAO, separate module, always available).
+    // implementation project(':conductor-es7-persistence')
+    implementation project(':conductor-os-persistence')
 
     implementation project(':conductor-redis-lock')
     implementation project(':conductor-redis-concurrency-limit')


### PR DESCRIPTION
## Summary
- Uncomments `:conductor-os-persistence` in `server/build.gradle` so the OpenSearch `IndexDAO` is bundled in the conductor-server image.
- Comments out `:conductor-es7-persistence` to follow upstream's own guidance (`// To use Opensearch, comment out above Elasticsearch...`). The two modules collide on bean names if both ever activate simultaneously.

## Why uncomment OS
Currently, setting `conductor.indexing.type=opensearch` in dev's `conductor-server.properties` causes the app to fail to boot:

```
No qualifying bean of type 'com.netflix.conductor.dao.IndexDAO' available
```

`PostgresIndexDAO` is deactivated by `indexing.type=opensearch`, and `OpenSearchRestDAO` isn't on the classpath because upstream commented out the `os-persistence` dependency by default.

## Why ALSO remove ES7 (initially I kept it — was wrong)
Both `ElasticSearchV7Configuration` and `OpenSearchConfiguration` declare:
- A `@Bean RestClient restClient(...)` (same bean name)
- A `@Primary @Bean IndexDAO ...IndexDAO(...)`

Today they're safe via mutually-exclusive Spring conditions (ES7: `elasticsearch.version=7`; OS: `indexing.type=opensearch`). But a single config typo setting both would cause boot failure with duplicate-bean / ambiguous-`@Primary` errors.

Mesta has never run ES7 (config has been `version=0` for the cluster's lifetime). The rollback path is `conductor.indexing.type=postgres` → `PostgresIndexDAO`, which lives in `:conductor-postgres-persistence` and stays in the classpath. So removing ES7 here loses zero rollback capability while removing a misconfiguration footgun.

## Motivation
Migrating Conductor task/workflow indexing off Postgres `task_index` (currently 10.6 GB, 24 JSONB upserts/sec on prime RDS, driving the `pg_toast_33022` autovacuum churn and the DiskQueueDepth alarm) and onto the existing Mesta OpenSearch cluster. Backfill of dev data into OS already validated end-to-end with [mesta-scripts/conductor-os-backfill](https://github.com/mestafi/mesta-scripts/tree/main/conductor-os-backfill).

## Risk
- **Image size**: small bump from the OS REST client + os-persistence JARs (~5-10 MB).
- **Behavior with old config**: zero. If `conductor.indexing.type=postgres` (current dev/prod), `PostgresIndexDAO` wins via `@ConditionalOnProperty`; OS DAO bean is not instantiated.
- **ES7 path removed**: not in use anywhere in Mesta config, so no actual regression.

## Test plan
- [ ] Build new image: `./gradlew :conductor-server:bootJar && docker build -t mesta-prd-nv-conductor-server:v3.16.0-os .`
- [ ] Confirm JAR present: `docker run --rm --entrypoint /bin/sh <image> -c "ls /app/libs | grep -iE 'os-persistence|opensearch'"`
- [ ] Confirm ES7 JAR absent: `docker run --rm --entrypoint /bin/sh <image> -c "ls /app/libs | grep -iE 'es7-persistence|elasticsearch-rest'"` should return nothing
- [ ] Push to ECR with new tag (e.g. `v3.16.0-os` or `v3.17.0`)
- [ ] Deploy to dev with `conductor.indexing.type=postgres` first — confirm no regression
- [ ] Then flip dev `indexing.type=opensearch` + OS connection props — confirm boot succeeds and `OpenSearchRestDAO` is wired
- [ ] Smoke: create a test workflow, verify it lands in OS `conductor_workflow` / `conductor_task` indexes
- [ ] Conductor UI: confirm workflow search, status filter, type filter, deep-link by ID all work
- [ ] Watch 24h, then promote to prod